### PR TITLE
Handle empty JSON files gracefully

### DIFF
--- a/gason.cpp
+++ b/gason.cpp
@@ -122,6 +122,8 @@ JsonParseStatus jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocato
 
 	bool separator = true;
 
+	*endptr = s;
+	
 	while (*s) {
 		JsonValue o;
 


### PR DESCRIPTION
This ensures endptr is always set to something sensible even if the input data was completely empty.
