### PR TITLE
Two small patches

### DIFF
--- a/pretty-print.cpp
+++ b/pretty-print.cpp
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
 #if !defined(_WIN32) && !defined(NDEBUG)
 	signal(SIGABRT, [](int) {
 		void *callstack[64];
-		int size = backtrace(callstack, arraySize(callstack));
+		int size = backtrace(callstack, sizeof(callstack)/sizeof(callstack[0]));
 		char **strings = backtrace_symbols(callstack, size);
 		for (int i = 0; i < size; ++i)
 			fprintf(stderr, "%s\n", strings[i]);

--- a/test-suite.cpp
+++ b/test-suite.cpp
@@ -124,7 +124,7 @@ int main() {
 #if !defined(_WIN32) && !defined(NDEBUG)
 	signal(SIGABRT, [](int) {
 		void *callstack[64];
-		int size = backtrace(callstack, arraySize(callstack));
+		int size = backtrace(callstack, sizeof(callstack)/sizeof(callstack[0]));
 		char **strings = backtrace_symbols(callstack, size);
 		for (int i = 0; i < size; ++i)
 			fprintf(stderr, "%s\n", strings[i]);


### PR DESCRIPTION
Two small patches:

1) I only recently realised the comment I have put in pretty-print (no need to call o.toNode before iterating). While it wouldn't be necessary if people read the documentation, who does that :)

2) I'm not sure how on other people's computer 'arraySize' is defined, but I just put in the normal C definition to get the code to compile on my mac.
