### PR TITLE
do not fail on all-whitespace

### DIFF
--- a/src/gason.cpp
+++ b/src/gason.cpp
@@ -141,8 +141,10 @@ int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator
     *endptr = s;
 
     while (*s) {
-        while (isspace(*s))
+        while (isspace(*s)) {
             ++s;
+            if (!*s) break;
+        }
         *endptr = s++;
         switch (**endptr) {
         case '-':


### PR DESCRIPTION
Currently, this reads past the buffer if the input is all whitespace. If it's null-terminated, `isspace()` will return false, but `*s` then violates the loop-invariant (`!=0`). Failing on bad input is fine, but crashing is a security hole, yes?

I don't want to add the extra test. The code is so efficient. Maybe there is a better way to handle this?