### PR TITLE
Null check

### DIFF
--- a/src/gason.cpp
+++ b/src/gason.cpp
@@ -27,6 +27,8 @@ void *JsonAllocator::allocate(size_t size) {
 
     size_t allocSize = sizeof(Zone) + size;
     Zone *zone = (Zone *)malloc(allocSize <= JSON_ZONE_SIZE ? JSON_ZONE_SIZE : allocSize);
+    if (zone == nullptr)
+        return nullptr;
     zone->used = allocSize;
     if (allocSize <= JSON_ZONE_SIZE || head == nullptr) {
         zone->next = head;
@@ -138,6 +140,7 @@ int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator
     JsonValue o;
     int pos = -1;
     bool separator = true;
+    JsonNode *node;
     *endptr = s;
 
     while (*s) {
@@ -315,11 +318,15 @@ int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator
                 keys[pos] = o.toString();
                 continue;
             }
-            tails[pos] = insertAfter(tails[pos], (JsonNode *)allocator.allocate(sizeof(JsonNode)));
+            if ((node = (JsonNode *) allocator.allocate(sizeof(JsonNode))) == nullptr)
+                return JSON_ALLOCATION_FAILURE;
+            tails[pos] = insertAfter(tails[pos], node);
             tails[pos]->key = keys[pos];
             keys[pos] = nullptr;
         } else {
-            tails[pos] = insertAfter(tails[pos], (JsonNode *)allocator.allocate(sizeof(JsonNode) - sizeof(char *)));
+            if ((node = (JsonNode *) allocator.allocate(sizeof(JsonNode) - sizeof(char *))) == nullptr)
+                return JSON_ALLOCATION_FAILURE;
+            tails[pos] = insertAfter(tails[pos], node);
         }
         tails[pos]->value = o;
     }

--- a/src/gason.h
+++ b/src/gason.h
@@ -96,7 +96,8 @@ inline JsonIterator end(JsonValue) {
     XX(MISMATCH_BRACKET, "mismatch bracket")         \
     XX(UNEXPECTED_CHARACTER, "unexpected character") \
     XX(UNQUOTED_KEY, "unquoted key")                 \
-    XX(BREAKING_BAD, "breaking bad")
+    XX(BREAKING_BAD, "breaking bad")                 \
+    XX(ALLOCATION_FAILURE, "allocation failure")
 
 enum JsonErrno {
 #define XX(no, str) JSON_##no,

--- a/src/test-suite.cpp
+++ b/src/test-suite.cpp
@@ -1,6 +1,7 @@
 #include "gason.h"
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 static int parsed;
 static int failed;

--- a/src/test-suite.cpp
+++ b/src/test-suite.cpp
@@ -20,6 +20,7 @@ void parse(const char *csource, bool ok) {
         ++failed;
     }
     ++parsed;
+    free(source);
 }
 
 #define pass(csource) parse(csource, true)


### PR DESCRIPTION
This branch addresses two memory issues.

* I noticed that the pointer returned by malloc wasn't checked against nullptr. This branch checks for nullptr and returns JSON_ALLOCATION_FAILURE.

* When I ran the test-suite under [Valgrind](http://valgrind.org/), it reported memory leaks. 

> ==5501== HEAP SUMMARY:
> ==5501==     in use at exit: 2,866 bytes in 43 blocks
> ==5501==   total heap usage: 65 allocs, 22 frees, 92,978 bytes allocated
> ==5501==
> ==5501== LEAK SUMMARY:
> ==5501==    definitely lost: 2,866 bytes in 43 blocks
> ==5501==    indirectly lost: 0 bytes in 0 blocks
> ==5501==      possibly lost: 0 bytes in 0 blocks
> ==5501==    still reachable: 0 bytes in 0 blocks
> ==5501==         suppressed: 0 bytes in 0 blocks
> ==5501== Rerun with --leak-check=full to see details of leaked memory
> ==5501==
> ==5501== For counts of detected and suppressed errors, rerun with: -v
> ==5501== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

Gason proper wasn't the problem. By freeing the pointer returned by strcpy in test-suite.cpp, [Valgrind](http://valgrind.org/) reports no leaks.

> ==5641== HEAP SUMMARY:
> ==5641==     in use at exit: 0 bytes in 0 blocks
> ==5641==   total heap usage: 65 allocs, 65 frees, 92,978 bytes allocated
> ==5641==
> ==5641== All heap blocks were freed -- no leaks are possible
> ==5641==
> ==5641== For counts of detected and suppressed errors, rerun with: -v
> ==5641== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)