### PR TITLE
C++11 good practices: constexpr instead of #define

### DIFF
--- a/src/gason.cpp
+++ b/src/gason.cpp
@@ -1,8 +1,8 @@
 #include "gason.h"
 #include <stdlib.h>
 
-#define JSON_ZONE_SIZE 4096
-#define JSON_STACK_SIZE 32
+constexpr size_t JSON_ZONE_SIZE = 4096;
+constexpr size_t JSON_STACK_SIZE = 32;
 
 const char *jsonStrError(int err) {
     switch (err) {
@@ -272,7 +272,7 @@ int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator
             o = listToValue(JSON_OBJECT, tails[pos--]);
             break;
         case '[':
-            if (++pos == JSON_STACK_SIZE)
+            if (++pos == static_cast<int>(JSON_STACK_SIZE))
                 return JSON_STACK_OVERFLOW;
             tails[pos] = nullptr;
             tags[pos] = JSON_ARRAY;
@@ -280,7 +280,7 @@ int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator
             separator = true;
             continue;
         case '{':
-            if (++pos == JSON_STACK_SIZE)
+            if (++pos == static_cast<int>(JSON_STACK_SIZE))
                 return JSON_STACK_OVERFLOW;
             tails[pos] = nullptr;
             tags[pos] = JSON_OBJECT;

--- a/src/gason.h
+++ b/src/gason.h
@@ -1,5 +1,6 @@
 #pragma once
 
+
 #include <stdint.h>
 #include <stddef.h>
 #include <assert.h>
@@ -16,10 +17,10 @@ enum JsonTag {
 
 struct JsonNode;
 
-#define JSON_VALUE_PAYLOAD_MASK 0x00007FFFFFFFFFFFULL
-#define JSON_VALUE_NAN_MASK 0x7FF8000000000000ULL
-#define JSON_VALUE_TAG_MASK 0xF
-#define JSON_VALUE_TAG_SHIFT 47
+constexpr unsigned long long JSON_VALUE_PAYLOAD_MASK = 0x00007FFFFFFFFFFFULL;
+constexpr unsigned long long JSON_VALUE_NAN_MASK = 0x7FF8000000000000ULL;
+constexpr unsigned long long JSON_VALUE_TAG_MASK = 0xF;
+constexpr unsigned long long JSON_VALUE_TAG_SHIFT = 47;
 
 union JsonValue {
     uint64_t ival;


### PR DESCRIPTION
No API breakage here, juste replacing some pre-processor macros by C++11 constant expressions.