### PR TITLE
Iterator pointer semantics fix

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -134,13 +134,13 @@ struct Gason {
         switch (v.getTag()) {
         case JSON_ARRAY:
             for (auto i : v) {
-                genStat(stat, i->value);
+                genStat(stat, i.value);
             }
             stat.arrayCount++;
             break;
         case JSON_OBJECT:
             for (auto i : v) {
-                genStat(stat, i->value);
+                genStat(stat, i.value);
                 stat.stringCount++;
             }
             stat.objectCount++;

--- a/src/gason.h
+++ b/src/gason.h
@@ -71,8 +71,8 @@ struct JsonIterator {
     bool operator!=(const JsonIterator &x) const {
         return p != x.p;
     }
-    JsonNode *operator*() const {
-        return p;
+    JsonNode& operator*() const {
+        return *p;
     }
     JsonNode *operator->() const {
         return p;

--- a/src/pretty-print.cpp
+++ b/src/pretty-print.cpp
@@ -62,8 +62,8 @@ void dumpValue(JsonValue o, int indent = 0) {
         fprintf(stdout, "[\n");
         for (auto i : o) {
             fprintf(stdout, "%*s", indent + SHIFT_WIDTH, "");
-            dumpValue(i->value, indent + SHIFT_WIDTH);
-            fprintf(stdout, i->next ? ",\n" : "\n");
+            dumpValue(i.value, indent + SHIFT_WIDTH);
+            fprintf(stdout, i.next ? ",\n" : "\n");
         }
         fprintf(stdout, "%*s]", indent, "");
         break;
@@ -75,10 +75,10 @@ void dumpValue(JsonValue o, int indent = 0) {
         fprintf(stdout, "{\n");
         for (auto i : o) {
             fprintf(stdout, "%*s", indent + SHIFT_WIDTH, "");
-            dumpString(i->key);
+            dumpString(i.key);
             fprintf(stdout, ": ");
-            dumpValue(i->value, indent + SHIFT_WIDTH);
-            fprintf(stdout, i->next ? ",\n" : "\n");
+            dumpValue(i.value, indent + SHIFT_WIDTH);
+            fprintf(stdout, i.next ? ",\n" : "\n");
         }
         fprintf(stdout, "%*s}", indent, "");
         break;


### PR DESCRIPTION
_API breakage here, but original API is erroneous._

The `JsonIterator::operator*` in gason does not implement correctly the pointer semantics. An iterator should be used in those ways (assuming `v` is a value containing an object).

```c++
for(auto it = begin(v); it != end(v); ++it)
  cout << it->key << endl;
```

```c++
for(auto node : v)
  cout << node.key << endl;
```

But in gason is used like this:

```c++
for(auto node : v)
  cout << node->key << endl;
```

This is not consistent with common behaviors of C++ iterators. This patch fixes it.

