### PR TITLE
Stop 32-bit pointer extension

### DIFF
--- a/src/gason.h
+++ b/src/gason.h
@@ -29,7 +29,7 @@ union JsonValue {
         : fval(x) {
     }
     JsonValue(JsonTag tag = JSON_NULL, void *payload = nullptr) {
-        assert((uint64_t)payload <= JSON_VALUE_PAYLOAD_MASK);
+        assert((uintptr_t)payload <= JSON_VALUE_PAYLOAD_MASK);
         ival = JSON_VALUE_NAN_MASK | ((uint64_t)tag << JSON_VALUE_TAG_SHIFT) | (uintptr_t)payload;
     }
     bool isDouble() const {


### PR DESCRIPTION
On ARM (maybe other systems), casting a 32-bit pointer to uint64_t is sign extended, so high pointers end up failing this check.

In practice, what we do is cast to uintptr_t, in the next line, so let's actually assert against that.

Fixes 32-bit ARM