### PR TITLE
Add const qualifier to jsonParse

### DIFF
--- a/src/gason.cpp
+++ b/src/gason.cpp
@@ -133,7 +133,7 @@ static inline JsonValue listToValue(JsonTag tag, JsonNode *tail) {
     return JsonValue(tag, nullptr);
 }
 
-int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator) {
+int jsonParse(const char *s, char **endptr, JsonValue *value, JsonAllocator &allocator) {
     JsonNode *tails[JSON_STACK_SIZE];
     JsonTag tags[JSON_STACK_SIZE];
     char *keys[JSON_STACK_SIZE];

--- a/src/gason.h
+++ b/src/gason.h
@@ -132,4 +132,4 @@ public:
     void deallocate();
 };
 
-int jsonParse(char *str, char **endptr, JsonValue *value, JsonAllocator &allocator);
+int jsonParse(const char *str, char **endptr, JsonValue *value, JsonAllocator &allocator);


### PR DESCRIPTION
It can be useful if our soruce (`s`) is a `std::string` and we use `c_str()` to get the underlying buffer.
On the other hand, it is always better to qualify types.